### PR TITLE
feat: implement 'save' and 'save all' with command mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,11 @@
         "when": "editorTextFocus && (extension.helixKeymap.searchMode || extension.helixKeymap.selectMode)"
       },
       {
+        "key": "backspace",
+        "command": "extension.helixKeymap.backspaceCommandMode",
+        "when": "extension.helixKeymap.commandMode"
+      },
+      {
         "key": "enter",
         "command": "extension.helixKeymap.exitSearchMode",
         "when": "editorTextFocus && (extension.helixKeymap.searchMode || extension.helixKeymap.selectMode)"

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -5,6 +5,7 @@ import {
   enterInsertMode,
   enterNormalMode,
   enterSearchMode,
+  enterCommandMode,
   enterSelectMode,
   enterVisualLineMode,
   enterVisualMode,
@@ -78,6 +79,10 @@ export const actions: Action[] = [
 
   parseKeysExact(['/'], [Mode.Normal], (helixState) => {
     enterSearchMode(helixState);
+  }),
+
+  parseKeysExact([':'], [Mode.Normal], (helixState) => {
+    enterCommandMode(helixState);
   }),
 
   parseKeysExact(['*'], [Mode.Normal], (_) => {

--- a/src/commandLine.ts
+++ b/src/commandLine.ts
@@ -1,11 +1,48 @@
+import * as vscode from 'vscode';
 import { HelixState } from './helix_state_types';
 import { StatusBar } from './statusBar';
+import { enterNormalMode } from './modes';
 // Create a class which has access to the VSCode status bar
 
 export class CommandLine {
+
+  // Buffer to save text written in the command-line
+  commandLineText = '';
+
+  // concatenate each keystroke to a buffer
+  addChar(helixState: HelixState, char: string): void{
+    if (char==='\n'){
+      // when the `enter` key is pressed
+      this.enter(helixState)
+      return;
+    }
+    this.commandLineText += char;
+    // display what the user has written in command mode
+    this.setText(this.commandLineText, helixState);
+  }
+  public clearCommandString(helixState: HelixState): void {
+    this.commandLineText = '';
+    this.setText(this.commandLineText, helixState);
+  }
   public setText(text: string, helixState: HelixState): void {
     StatusBar.setText(helixState, text);
   }
+  enter(helixState: HelixState): void{
+      if (this.commandLineText === "w") {
+        vscode.window.activeTextEditor?.document.save();
+      } else if (this.commandLineText === "wa"){
+        vscode.workspace.saveAll(true);
+      }
+      this.commandLineText = '';
+      this.setText(this.commandLineText, helixState);
+      enterNormalMode(helixState);
+  }
+  
+  backspace(helixState: HelixState): void {
+    this.commandLineText = this.commandLineText.slice(0, -1) 
+    this.setText(this.commandLineText, helixState);
+  }
+
 }
 
 export const commandLine = new CommandLine();

--- a/src/escape_handler.ts
+++ b/src/escape_handler.ts
@@ -6,6 +6,7 @@ import { Mode } from './modes_types';
 import * as positionUtils from './position_utils';
 import { typeHandler } from './type_handler';
 import { addTypeSubscription } from './type_subscription';
+import { commandLine } from './commandLine';
 
 export function escapeHandler(vimState: HelixState): void {
   const editor = vscode.window.activeTextEditor;
@@ -60,8 +61,9 @@ export function escapeHandler(vimState: HelixState): void {
         vscode.TextEditorRevealType.InCenterIfOutsideViewport,
       );
     }
-  } else if (vimState.mode === Mode.View) {
-    enterNormalMode(vimState);
+  } else if (vimState.mode === Mode.View || vimState.mode === Mode.CommandlineInProgress) {
+      commandLine.clearCommandString(vimState);
+      enterNormalMode(vimState);
   }
 
   vimState.keysPressed = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,9 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand('extension.helixKeymap.backspaceSearchMode', () => {
       globalhelixState.searchState.backspace(globalhelixState);
     }),
+    vscode.commands.registerCommand('extension.helixKeymap.backspaceCommandMode', () => {
+      globalhelixState.commandLine.backspace(globalhelixState);
+    }),
     vscode.commands.registerCommand('extension.helixKeymap.nextSearchResult', () =>
       globalhelixState.searchState.nextSearchResult(globalhelixState),
     ),

--- a/src/modes.ts
+++ b/src/modes.ts
@@ -30,6 +30,13 @@ export function enterSearchMode(helixState: HelixState): void {
   helixState.commandLine.setText('', helixState);
 }
 
+export function enterCommandMode(helixState: HelixState): void {
+  helixState.mode = Mode.CommandlineInProgress;
+  setModeContext('extension.helixKeymap.commandMode')
+  helixState.commandLine.setText('', helixState);
+
+}
+
 export function enterSelectMode(helixState: HelixState): void {
   helixState.mode = Mode.Select;
   setModeContext('extension.helixKeymap.selectMode');
@@ -77,6 +84,7 @@ function setModeContext(key: string) {
     'extension.helixKeymap.selectMode',
     'extension.helixKeymap.viewMode',
     'extension.helixKeymap.disabledMode',
+    'extension.helixKeymap.commandMode'
   ];
 
   modeKeys.forEach((modeKey) => {

--- a/src/type_handler.ts
+++ b/src/type_handler.ts
@@ -10,6 +10,10 @@ export function typeHandler(helixState: HelixState, char: string): void {
     helixState.searchState.addChar(helixState, char);
     return;
   }
+  if (helixState.mode == Mode.CommandlineInProgress){
+    helixState.commandLine.addChar(helixState, char);
+    return;
+  }
   const editor = vscode.window.activeTextEditor;
   if (!editor) return;
 


### PR DESCRIPTION
This pull request implements #25. It implements the "save[w]" and "save all[wa]" helix commands accessible wia `:w` and `:wa`. 

Further pull requests implementing a sub-set of such helix commands will follow.

Thank you.