### PR TITLE
fix: correct selection clearing logic on entering insert mode

### DIFF
--- a/src/modes.ts
+++ b/src/modes.ts
@@ -8,8 +8,9 @@ export function enterInsertMode(helixState: HelixState, before = true): void {
   // To fix https://github.com/jasonwilliams/vscode-helix/issues/14 we should clear selections on entering insert mode
   // Helix doesn't clear selections on insert but doesn't overwrite the selection either, so our best option is to just clear them
   const editor = helixState.editorState.activeEditor!;
+  
   editor.selections = editor.selections.map((selection) => {
-    const position = before ? selection.anchor : selection.active;
+    const position = before ? selection.start : selection.end;
     return new vscode.Selection(position, position);
   });
 


### PR DESCRIPTION
follow helix a - insert mode in end of selection, i - insert mode on start of selection