### PR TITLE
Closer to helix parity for small interactions

### DIFF
--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -137,12 +137,18 @@ export const actions: Action[] = [
     [KeyMap.Actions.InsertMode],
     [Mode.Normal, Mode.Visual, Mode.VisualLine, Mode.Occurrence],
     (vimState, editor) => {
+      // In visual mode, move cursor to start of selection before entering insert mode
+      if (vimState.mode === Mode.Visual || vimState.mode === Mode.VisualLine) {
+        editor.selections = editor.selections.map((selection) => {
+          const start = selection.start.isBeforeOrEqual(selection.end) ? selection.start : selection.end;
+          return new vscode.Selection(start, start);
+        });
+      }
       enterInsertMode(vimState);
       setModeCursorStyle(vimState.mode, editor);
       removeTypeSubscription(vimState);
     },
   ),
-
   parseKeysExact([KeyMap.Actions.InsertAtLineStart], [Mode.Normal], (vimState, editor) => {
     editor.selections = editor.selections.map((selection) => {
       const character = editor.document.lineAt(selection.active.line).firstNonWhitespaceCharacterIndex;
@@ -154,13 +160,11 @@ export const actions: Action[] = [
     setModeCursorStyle(vimState.mode, editor);
     removeTypeSubscription(vimState);
   }),
-
   parseKeysExact(['a'], [Mode.Normal], (vimState, editor) => {
     enterInsertMode(vimState, false);
     setModeCursorStyle(vimState.mode, editor);
     removeTypeSubscription(vimState);
   }),
-
   parseKeysExact([KeyMap.Actions.InsertAtLineEnd], [Mode.Normal], (vimState, editor) => {
     editor.selections = editor.selections.map((selection) => {
       const lineLength = editor.document.lineAt(selection.active.line).text.length;
@@ -172,14 +176,20 @@ export const actions: Action[] = [
     setModeCursorStyle(vimState.mode, editor);
     removeTypeSubscription(vimState);
   }),
-
   parseKeysExact(['v'], [Mode.Normal, Mode.VisualLine], (vimState, editor) => {
     enterVisualMode(vimState);
     setModeCursorStyle(vimState.mode, editor);
   }),
-
-  parseKeysExact(['x'], [Mode.Normal, Mode.Visual], () => {
-    vscode.commands.executeCommand('expandLineSelection');
+  parseKeysExact(['x'], [Mode.Normal, Mode.Visual], (vimState, editor) => {
+    editor.selections = editor.selections.map((selection) => {
+      const line = editor.document.lineAt(selection.active.line);
+      return new vscode.Selection(
+        new vscode.Position(selection.active.line, 0),
+        new vscode.Position(selection.active.line, line.text.length),
+      );
+    });
+    enterVisualLineMode(vimState);
+    setModeCursorStyle(vimState.mode, editor);
   }),
 
   parseKeysExact([KeyMap.Actions.NewLineBelow], [Mode.Normal], (vimState, editor) => {

--- a/src/actions/matchMode.ts
+++ b/src/actions/matchMode.ts
@@ -9,11 +9,15 @@ import { delete_, yank } from './operators';
 
 export const matchActions: Action[] = [
   // Implemenent jump to bracket
-  parseKeysExact(['m', 'm'], [Mode.Normal], () => {
+  parseKeysExact(['m', 'm'], [Mode.Normal], (_, editor) => {
+    const cursor = editor.selection.active;
+    editor.selection = new vscode.Selection(cursor, cursor);
     vscode.commands.executeCommand('editor.action.jumpToBracket');
   }),
 
-  parseKeysExact(['m', 'm'], [Mode.Visual], () => {
+  parseKeysExact(['m', 'm'], [Mode.Visual], (_, editor) => {
+    const cursor = editor.selection.active;
+    editor.selection = new vscode.Selection(cursor, cursor);
     vscode.commands.executeCommand('editor.action.selectToBracket');
   }),
 

--- a/src/actions/operator_ranges.ts
+++ b/src/actions/operator_ranges.ts
@@ -415,9 +415,10 @@ function createWordForwardHandler(
     const result = ranges.find((x) => x.start > position.character);
 
     if (result) {
-      return new vscode.Range(position, position.with({ character: result.start }));
+      // Include the character under cursor in the range
+      return new vscode.Range(position, position.with({ character: result.start - 1 }));
     } else {
-      return new vscode.Range(position, position.with({ character: lineText.length }));
+      return new vscode.Range(position, position.with({ character: lineText.length - 1 }));
     }
   };
 }
@@ -432,6 +433,7 @@ function createWordBackwardHandler(
     const result = ranges.reverse().find((x) => x.start < position.character);
 
     if (result) {
+      // Include the character under cursor in the range
       return new vscode.Range(position.with({ character: result.start }), position);
     } else {
       return undefined;
@@ -449,7 +451,8 @@ function createWordEndHandler(
     const result = ranges.find((x) => x.end > position.character);
 
     if (result) {
-      return new vscode.Range(position, positionUtils.right(document, position.with({ character: result.end })));
+      // Include the character under cursor in the range
+      return new vscode.Range(position, position.with({ character: result.end }));
     } else {
       return undefined;
     }

--- a/src/selection_utils.ts
+++ b/src/selection_utils.ts
@@ -7,7 +7,7 @@ export function vscodeToVimVisualSelection(
   vscodeSelection: vscode.Selection,
 ): vscode.Selection {
   if (vscodeSelection.active.isBefore(vscodeSelection.anchor)) {
-    return new vscode.Selection(positionUtils.left(vscodeSelection.anchor), vscodeSelection.active);
+    return new vscode.Selection(vscodeSelection.anchor, vscodeSelection.active);
   } else {
     return new vscode.Selection(vscodeSelection.anchor, positionUtils.left(vscodeSelection.active));
   }
@@ -18,7 +18,7 @@ export function vimToVscodeVisualSelection(
   vimSelection: vscode.Selection,
 ): vscode.Selection {
   if (vimSelection.active.isBefore(vimSelection.anchor)) {
-    return new vscode.Selection(positionUtils.right(document, vimSelection.anchor), vimSelection.active);
+    return new vscode.Selection(vimSelection.anchor, vimSelection.active);
   } else {
     return new vscode.Selection(vimSelection.anchor, positionUtils.right(document, vimSelection.active));
   }

--- a/src/word_utils.ts
+++ b/src/word_utils.ts
@@ -11,21 +11,21 @@ export function whitespaceWordRanges(text: string): { start: number; end: number
   const ranges = []
 
   for (let i = 0; i < text.length; ++i) {
-    const char = text[i]
+    const char = text[i];
 
     if (state === State.Whitespace) {
       if (!isWhitespaceCharacter(char)) {
-        startIndex = i
-        state = State.Word
+        startIndex = i;
+        state = State.Word;
       }
     } else {
       if (isWhitespaceCharacter(char)) {
         ranges.push({
           start: startIndex,
           end: i - 1,
-        })
+        });
 
-        state = State.Whitespace
+        state = State.Whitespace;
       }
     }
   }


### PR DESCRIPTION
[X] `m m` bracket matching uses cursor position instead of selection start

[X] Line boundaries excluded from word motion boundaries

[X] Support for `h` and `l` motions in visual mode

[X] `x` motion overflowing to new line

[X] `w` and `b` motions now correctly handle inclusive cursor behavior

[X] Cursor positioned at start of selection on insert across back and forward motions