### PR TITLE
Feat: add g + i key combination to go to implementation

### DIFF
--- a/src/actions/gotoMode.ts
+++ b/src/actions/gotoMode.ts
@@ -74,6 +74,10 @@ export const gotoActions: Action[] = [
     commands.executeCommand('editor.action.revealDefinition');
   }),
 
+  parseKeysExact(['g', 'i'], [Mode.Normal], () => {
+    commands.executeCommand('editor.action.goToImplementation');
+  }),
+
   parseKeysExact(['g', 'y'], [Mode.Normal], () => {
     commands.executeCommand('editor.action.goToTypeDefinition');
   }),


### PR DESCRIPTION
This PR add the g + i command to execute the "Go To Implementation". That's pretty much it, let me know if any additional info is necessary. 