### PR TITLE
Fix paste commands "p" and "P" 

### DIFF
--- a/src/put_utils/put_after.ts
+++ b/src/put_utils/put_after.ts
@@ -70,10 +70,7 @@ function normalModeCharacterwise(
   editor: vscode.TextEditor,
   registerContentsList: (string | undefined)[],
 ) {
-  const insertPositions = editor.selections.map((selection) => {
-    return positionUtils.right(editor.document, selection.active);
-  });
-
+  const insertPositions = editor.selections.map((selection) => selection.end);
   const adjustedInsertPositions = adjustInsertPositions(insertPositions, registerContentsList);
   const insertRanges = getInsertRangesFromBeginning(adjustedInsertPositions, registerContentsList);
 

--- a/src/put_utils/put_before.ts
+++ b/src/put_utils/put_before.ts
@@ -59,7 +59,7 @@ function normalModeCharacterwise(
   editor: vscode.TextEditor,
   registerContentsList: (string | undefined)[],
 ) {
-  const insertPositions = editor.selections.map((selection) => selection.active);
+  const insertPositions = editor.selections.map((selection) => selection.start);
   const adjustedInsertPositions = adjustInsertPositions(insertPositions, registerContentsList);
   const insertRanges = getInsertRangesFromBeginning(adjustedInsertPositions, registerContentsList);
 


### PR DESCRIPTION
Now pasting after and before current selection.  (was incorrectly relative to cursor).
Fixing bug #39, #18