### PR TITLE
fix(editor): ensure cursor style and line numbering match mode on editor change

### DIFF
--- a/src/eventHandlers.ts
+++ b/src/eventHandlers.ts
@@ -18,6 +18,11 @@ export function onDidChangeActiveTextEditor(helixState: HelixState, editor: Text
   helixState.editorState.previousEditor = helixState.editorState.activeEditor;
   helixState.editorState.activeEditor = editor;
   helixState.symbolProvider.refreshTree(editor.document.uri);
+
+  // Ensure new editors always have the correct cursor style and line numbering
+  // applied according to the current mode
+  setModeCursorStyle(helixState.mode, editor);
+  setRelativeLineNumbers(helixState.mode, editor);
 }
 
 export function onSelectionChange(helixState: HelixState, e: TextEditorSelectionChangeEvent): void {

--- a/src/eventHandlers.ts
+++ b/src/eventHandlers.ts
@@ -22,7 +22,6 @@ export function onDidChangeActiveTextEditor(helixState: HelixState, editor: Text
   // Ensure new editors always have the correct cursor style and line numbering
   // applied according to the current mode
   setModeCursorStyle(helixState.mode, editor);
-  setRelativeLineNumbers(helixState.mode, editor);
 }
 
 export function onSelectionChange(helixState: HelixState, e: TextEditorSelectionChangeEvent): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { addTypeSubscription, removeTypeSubscription } from './type_subscription
 
 const globalhelixState: HelixState = {
   typeSubscription: undefined,
-  mode: Mode.Insert,
+  mode: Mode.Normal,
   keysPressed: [],
   numbersPressed: [],
   resolveCount: function () {


### PR DESCRIPTION
I was getting issues where the cursor style was not reflecting the actual current mode, particularly when opening existing files in a new editor.  This PR is aimed at ensuring the cursor style is correctly set on opening new editors.

- Set cursor style and line numbering when active editor changes
- Default to Normal mode instead of Insert mode on initialisation
- Applies mode-specific settings consistently across all editors