### PR TITLE
fix: append after (a)

### DIFF
--- a/src/modes.ts
+++ b/src/modes.ts
@@ -10,7 +10,15 @@ export function enterInsertMode(helixState: HelixState, before = true): void {
   const editor = helixState.editorState.activeEditor!;
   
   editor.selections = editor.selections.map((selection) => {
-    const position = before ? selection.start : selection.end;
+    let position = before ? selection.start : selection.end;
+    
+    // For 'a' key (before = false), move cursor one position right (append after)
+    if (!before) {
+      const line = editor.document.lineAt(position.line);
+      const newChar = Math.min(position.character + 1, line.text.length);
+      position = position.with({ character: newChar });
+    }
+    
     return new vscode.Selection(position, position);
   });
 


### PR DESCRIPTION
This pull request solves #37. Now, `append (a)` works as expected by inserting the cursor AFTER the caret.