### PR TITLE
fix: cursor position exiting insert mode

### DIFF
--- a/src/escape_handler.ts
+++ b/src/escape_handler.ts
@@ -15,8 +15,8 @@ export function escapeHandler(vimState: HelixState): void {
 
   if (vimState.mode === Mode.Insert || vimState.mode === Mode.Occurrence) {
     editor.selections = editor.selections.map((selection) => {
-      const newPosition = positionUtils.left(selection.active);
-      return new vscode.Selection(newPosition, newPosition);
+      return new vscode.Selection(selection.active, selection.active);
+
     });
 
     enterNormalMode(vimState);


### PR DESCRIPTION
This PR fixes #59, where going to Normal mode from Insert messes up the cursor position by shifting the cursor to the left by 1.